### PR TITLE
Return to Waypoint

### DIFF
--- a/commands/resetdrive.py
+++ b/commands/resetdrive.py
@@ -1,4 +1,5 @@
 from commands2 import CommandBase
+from wpimath.geometry._geometry import Pose2d
 
 from subsystems.drivesubsystem import DriveSubsystem
 
@@ -12,6 +13,7 @@ class ResetDrive(CommandBase):
 
     def initialize(self) -> None:
         print("Command: {}".format(self.getName()))
+        self.drive.returnPos = self.drive.shiftPoint(self.drive.returnPos, self.drive.odometry.getPose())
 
     def execute(self) -> None:
         self.drive.resetSwerveModules()

--- a/commands/returndrive.py
+++ b/commands/returndrive.py
@@ -1,0 +1,58 @@
+import typing
+from typing import Tuple
+from commands2 import CommandBase
+from subsystems.drivesubsystem import DriveSubsystem
+from math import sqrt
+
+class ReturnDrive(CommandBase):
+    def __init__(
+        self,
+        drive: DriveSubsystem,
+        scaler: typing.Callable[[], float],
+        rotation: typing.Callable[[], float]
+    ) -> None:
+        CommandBase.__init__(self)
+        self.setName(__class__.__name__)
+
+        self.drive = drive
+        self.scaler = scaler
+        self.rotation = rotation
+
+        self.addRequirements([self.drive])
+        self.setName(__class__.__name__)
+    
+    def Deadband(self, input: float, deadband: float) -> float:
+        if abs(input) <= deadband:
+            return 0
+        else: 
+            return input
+
+    def normalize(self, x: float, y: float) -> Tuple[float, float]:
+        length = sqrt(pow(x, 2) + pow(y, 2))
+        
+        if length == 0:
+            return 0, 0
+        elif length <= 1:
+            return x, y
+        return x/length, y/length
+
+    def getDirection(self) -> Tuple[float, float]:
+
+        returnPos = self.drive.returnPos
+        currentPos = self.drive.odometry.getPose()
+
+        xDelta = currentPos.X() - returnPos.X()
+        yDelta = currentPos.Y() - returnPos.Y()
+
+        return self.normalize(float(xDelta * -1), float(yDelta * -1))
+        
+    def execute(self) -> None:
+
+        deadband = 0.1
+
+        self.drive.arcadeDriveWithFactors(
+            self.Deadband(self.getDirection()[0], deadband) * self.scaler(),
+            self.Deadband(self.getDirection()[1], deadband) * self.scaler(),
+            self.rotation() * -1,
+            DriveSubsystem.CoordinateMode.FieldRelative,
+        )

--- a/commands/setreturn.py
+++ b/commands/setreturn.py
@@ -1,0 +1,23 @@
+from commands2 import CommandBase
+
+from subsystems.drivesubsystem import DriveSubsystem
+
+
+class SetReturn(CommandBase):
+    def __init__(self, drive: DriveSubsystem) -> None:
+        CommandBase.__init__(self)
+
+        self.drive = drive
+
+    def initialize(self) -> None:
+        currentPose = self.drive.odometry.getPose()
+        self.drive.returnPos = currentPose
+
+        currentX = currentPose.X()
+        currentY = currentPose.Y()
+
+        print("New Coordinates \nX: {0}, Y: {1}".format(currentX, currentY))
+        
+
+    def isFinished(self) -> bool:
+        return True

--- a/constants.py
+++ b/constants.py
@@ -288,3 +288,5 @@ kXboxJoystickDeadband = 0.1
 
 kKeyboardJoystickDeadband = 0.0
 """dimensionless"""
+
+

--- a/operatorinterface.py
+++ b/operatorinterface.py
@@ -38,6 +38,10 @@ class HolonomicInput:
         self.sideToSide = sideToSide
         self.rotation = rotation
 
+class CameraControl:
+    def __init__(self, leftRight: AnalogInput, upDown: AnalogInput):
+        self.leftRight = leftRight
+        self.upDown = upDown
 
 class OperatorInterface:
     """
@@ -48,6 +52,21 @@ class OperatorInterface:
         self.xboxController = XboxController(constants.kXboxControllerPort)
         self.translationController = Joystick(constants.kTranslationControllerPort)
         self.rotationController = Joystick(constants.kRotationControllerPort)
+        
+        self.scaler = lambda: (self.xboxController.getTriggerAxis(GenericHID.Hand.kRightHand) -1 ) * -1
+        self.rotation = lambda: self.xboxController.getX(GenericHID.Hand.kRightHand)
+
+        self.returnPositionInput = (
+            self.xboxController,
+            180,
+            0 
+        )
+
+        self.returnModeControl = (
+            self.xboxController,
+            0, 
+            0
+        )
 
         self.coordinateModeControl = (
             self.xboxController,
@@ -82,21 +101,17 @@ class OperatorInterface:
 
         self.chassisControls = HolonomicInput(
             Invert(
-                Deadband(
-                    lambda: self.xboxController.getY(GenericHID.Hand.kLeftHand),
-                    constants.kXboxJoystickDeadband,
-                )
+                Deadband(lambda: self.xboxController.getY(GenericHID.Hand.kLeftHand) * self.scaler(), constants.kXboxJoystickDeadband)
+            ),
+            Invert(
+                Deadband(lambda: self.xboxController.getX(GenericHID.Hand.kLeftHand) * self.scaler(), constants.kXboxJoystickDeadband)
+
             ),
             Invert(
                 Deadband(
-                    lambda: self.xboxController.getX(GenericHID.Hand.kLeftHand),
-                    constants.kXboxJoystickDeadband,
-                )
-            ),
-            Invert(
-                Deadband(
-                    lambda: self.xboxController.getX(GenericHID.Hand.kRightHand),
+                    lambda: self.rotation(),
                     constants.kXboxJoystickDeadband,
                 )
             ),
         )
+

--- a/robotcontainer.py
+++ b/robotcontainer.py
@@ -11,6 +11,10 @@ from commands.defaultdrive import DefaultDrive
 from commands.fieldrelativedrive import FieldRelativeDrive
 from commands.resetdrive import ResetDrive
 
+from commands.returndrive import ReturnDrive
+
+from commands.setreturn import SetReturn
+
 from subsystems.drivesubsystem import DriveSubsystem
 
 from operatorinterface import OperatorInterface
@@ -31,7 +35,7 @@ class RobotContainer:
 
         # The robot's subsystems
         self.drive = DriveSubsystem()
-
+        
         # Autonomous routines
 
         # A simple auto routine that drives forward a specified distance, and then stops.
@@ -83,9 +87,18 @@ class RobotContainer:
             )
         )
 
+
         commands2.button.JoystickButton(
             *self.operatorInterface.resetSwerveControl
         ).whenPressed(ResetDrive(self.drive))
+    
+        commands2.button.POVButton(
+            *self.operatorInterface.returnPositionInput
+        ).whenPressed(SetReturn(self.drive))
+
+        commands2.button.POVButton(
+            *self.operatorInterface.returnModeControl
+        ).whileHeld(ReturnDrive(self.drive, self.operatorInterface.scaler, self.operatorInterface.rotation))
 
     def getAutonomousCommand(self) -> commands2.Command:
         return self.chooser.getSelected()

--- a/subsystems/drivesubsystem.py
+++ b/subsystems/drivesubsystem.py
@@ -1,3 +1,4 @@
+from math import cos, sin
 from commands2 import SubsystemBase
 from wpilib import Encoder, PWMVictorSPX, RobotBase, Timer
 from ctre import (
@@ -18,6 +19,7 @@ from wpimath.kinematics import (
     SwerveDrive4Odometry,
 )
 from enum import Enum, auto
+from typing import Tuple
 import constants
 
 
@@ -425,6 +427,8 @@ class DriveSubsystem(SubsystemBase):
         self.printTimer = Timer()
         # self.printTimer.start()
 
+        self.returnPos = Pose2d(0, 0, 0)
+
     def resetSwerveModules(self):
         for module in self.modules:
             module.reset()
@@ -528,3 +532,19 @@ class DriveSubsystem(SubsystemBase):
         self.frontRightModule.applyState(frontRightState)
         self.backLeftModule.applyState(backLeftState)
         self.backRightModule.applyState(backRightState)
+
+    def rotatePoint(self, x: float, y: float, angle: float, ccw: bool) -> Tuple[float, float]:
+        invert = ccw*2 - 1
+
+        xNew = x*cos(angle) - y*sin(angle)*invert
+        yNew = x*sin(angle) + y*cos(angle)*invert
+        return xNew, yNew
+
+    def shiftPoint(self, savedPose: Pose2d, currentPose: Pose2d) -> Pose2d:
+        xDelta = savedPose.X() - currentPose.X() 
+        yDelta = savedPose.Y() - currentPose.Y() 
+
+        coords = self.rotatePoint(xDelta, yDelta, currentPose.rotation().radians() * -1, True)
+
+        return Pose2d(coords[0], coords[1], 0)
+        


### PR DESCRIPTION
Returns to set point on the field
- Waypoint automatically set to startup location
- Waypoint stays in the same place through field reset
- Rotation and speed scaling possible while returning

Added Controls
- DPad Up: Drives to waypoint while held
- DPad Down: Sets current location to waypoint