### PR TITLE
Make pylint go green

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,6 +1,6 @@
 name: Pylint
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint
+        pip install -r requirements.txt
     - name: Analysing the code with pylint
       run: |
-        pylint `ls -R|grep .py$|xargs`
+        pylint -E --extension-pkg-whitelist=ctre,wpimath.geometry,math,commands2,wpilib $(git ls-files '*.py')

--- a/commands/complexauto.py
+++ b/commands/complexauto.py
@@ -2,7 +2,7 @@ from commands2 import SequentialCommandGroup
 
 import constants
 
-from .drivedistance import DriveDistance
+from commands.drivedistance import DriveDistance
 from subsystems.drivesubsystem import DriveSubsystem
 
 

--- a/operatorinterface.py
+++ b/operatorinterface.py
@@ -50,12 +50,6 @@ class CameraControl:
         self.leftRight = leftRight
         self.upDown = upDown
 
-class CameraControl:
-    def __init__(self, leftRight: AnalogInput, upDown: AnalogInput):
-        self.leftRight = leftRight
-        self.upDown = upDown
-
-
 class OperatorInterface:
     """
     The controls that the operator(s)/driver(s) interact with

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# Eventually these should probably be version pinned
+robotpy[all]
+pyyaml
+pylint


### PR DESCRIPTION
* In the interest of seeing the pylint github action go green, I switched it to error only mode and cleaned up the two errors.
* Add a requirements.txt for our pip requirements
* remove 3.10 from the lint targets since it doesn't appear that there are robotpy binary packages yet

Next step will be to go through all the pylint warnings, create an rc file to ignore some related to robotpy we can't fix and clean up any others so we can run with warnings on.